### PR TITLE
Reduce aws-sdk-go update frequency to weekly

### DIFF
--- a/default.json
+++ b/default.json
@@ -26,6 +26,12 @@
       "description": "Group Kubernetes packages",
       "matchPackagePatterns": ["^kubernetes/", "^k8s\\.gcr\\.io/"],
       "groupName": "Kubernetes packages"
+    },
+    {
+      "description": "Updates daily with mostly noise",
+      "matchPackageNames": ["github.com/aws/aws-sdk-go"],
+      "groupName": "aws-sdk",
+      "extends": ["schedule:weekly"]
     }
   ],
   "regexManagers": [


### PR DESCRIPTION
aws-sdk-go auto-releases daily, and almost all updates are uninteresting.  Force this package to only get updated weekly.