### PR TITLE
Refine kubernetes group

### DIFF
--- a/default.json
+++ b/default.json
@@ -24,7 +24,7 @@
     },
     {
       "description": "Group Kubernetes packages",
-      "matchPackagePatterns": ["^kubernetes/", "^k8s\\.gcr\\.io/"],
+      "matchPackagePatterns": ["^kubernetes/", "^k8s\\.gcr\\.io/kube-"],
       "groupName": "Kubernetes packages"
     },
     {


### PR DESCRIPTION
Refine kubernetes package pattern.

Want to group 'core' packages like:
- `k8s.gcr.io/kube-proxy`
- `k8s.gcr.io/kube-apiserver`

... but not community packages like:
- `k8s.gcr.io/external-dns/external-dns`
- `k8s.gcr.io/metrics-server/metrics-server`