### PR TITLE
k8s: Add registry.k8s.io and separate minor+patch

### DIFF
--- a/default.json
+++ b/default.json
@@ -24,8 +24,9 @@
     },
     {
       "description": "Group Kubernetes packages",
-      "matchPackagePatterns": ["^kubernetes/", "^k8s\\.gcr\\.io/kube-"],
-      "groupName": "Kubernetes packages"
+      "matchPackagePatterns": ["^kubernetes/", "^k8s\\.gcr\\.io/kube-", "^registry\\.k8s\\.io/kube-"],
+      "groupName": "Kubernetes packages",
+      "separateMinorPatch": true
     },
     {
       "description": "Updates daily with mostly noise",


### PR DESCRIPTION
Add new registry.k8s.io to the list of Kubernetes package patterns.

Create separate minor and patch PRs by default for Kubernetes, since Kubernetes treats its minor versions seriously.